### PR TITLE
feat: returned program with it's size when LoadBinary

### DIFF
--- a/app/main_app.c
+++ b/app/main_app.c
@@ -164,15 +164,15 @@ void loop(SDL_Renderer* rend)
 
 int main()
 {
-  struct PROGRAM_LINE * program = LoadBinary("resources/dump.bin");
+  struct PROGRAM programLoaded = LoadBinary("resources/dump.bin");
 
-  for (int i = 0; i < 8; i++) {
+  for (int i = 0; i < programLoaded.lines; i++) {
     printf(
         "%s 0x%02X 0x%02X 0x%02X \n",
-        program[i].opcode->instruction,
-        program[i].opcode->hex & 0xFF,
-        program[i].args[0] & 0xFF,
-        program[i].args[1] & 0xFF);
+        programLoaded .program[i].opcode->instruction,
+        programLoaded .program[i].opcode->hex & 0xFF,
+        programLoaded .program[i].args[0] & 0xFF,
+        programLoaded .program[i].args[1] & 0xFF);
   }
 
   SDL_Window* win = init_window();

--- a/src/constants.h
+++ b/src/constants.h
@@ -30,6 +30,11 @@ struct PROGRAM_LINE {
   char args[3];
 };
 
+struct PROGRAM {
+  struct PROGRAM_LINE * program;
+  int lines;
+};
+
 extern enum ADDRESSING_MODE_INDEX addressing;
 extern struct ADDRESSING_MODE addressing_modes[13];
 extern struct OPCODE opcodes[151];

--- a/src/disassembler.c
+++ b/src/disassembler.c
@@ -15,7 +15,7 @@ struct OPCODE * GetOpcode(char hex) {
   return NULL;
 }
 
-struct PROGRAM_LINE * LoadBinary(char * binaryPath) {
+struct PROGRAM LoadBinary(char * binaryPath) {
   //forneceu algum conteúdo como argumento?
   if(strlen(binaryPath) <= 0) {
     printf("invalid file path %s", binaryPath);
@@ -50,7 +50,7 @@ struct PROGRAM_LINE * LoadBinary(char * binaryPath) {
   int argumentCount = 0;
   struct OPCODE * opcode = NULL;
 
-  struct PROGRAM_LINE *program = malloc(sizeof *program * fileSize);
+  struct PROGRAM_LINE * program = malloc(sizeof(* program) * fileSize);
 
   while(fread(&buffer, 1, 1, file) > 0) {
     //por enquanto, ignorando os argumentos para entender se os opcodes são identificados corretamente
@@ -69,8 +69,8 @@ struct PROGRAM_LINE * LoadBinary(char * binaryPath) {
       printf("0x%02X => FAIL !!!\n", buffer & 0xFF);
       continue;
     }
-    else
-      program[programLine].opcode = opcode;
+
+    program[programLine].opcode = opcode;
 
     //adiciona argumentos para ignorar nas próximas iterações, argumentCount-- no começo do while
     argumentCount = opcode->addressing->length - 1;
@@ -79,5 +79,10 @@ struct PROGRAM_LINE * LoadBinary(char * binaryPath) {
   //fechando o arquivo para não ter memory leak
   fclose(file);
 
-  return program;
+  struct PROGRAM programLoaded = {
+    .program = program,
+    .lines = programLine + 1 // +1 por conta da variável iniciar em -1, ou seja, conta a linha 0;
+  };
+
+  return programLoaded ;
 }

--- a/src/disassembler.h
+++ b/src/disassembler.h
@@ -1,2 +1,2 @@
 struct OPCODE * GetOpcode(char hex);
-struct PROGRAM_LINE* LoadBinary(char * binaryPath);
+struct PROGRAM LoadBinary(char * binaryPath);


### PR DESCRIPTION
Isn't possible to get sizes malloc'ed, it's returns only a pointer with a memory mapped region with the size available...
The only way to do that is return the program lines readed as size.
By the way, `struct PROGRAM_LINE * program = malloc(sizeof(* program) * fileSize);` is allocating way more space than needed.
Probably we could understand how to use malloc/realloc for dynamically allocate and reallocate memory sizes.