### PR TITLE
feat: Adds opcodes JMP, JSR & RTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ sudo apt-get install clang cmake libsdl2-dev
 - [ ] INC
 - [x] INX
 - [x] INY
-- [ ] JMP
-- [ ] JSR
+- [x] JMP
+- [x] JSR
 - [x] LDA
 - [x] LDX
 - [x] LDY
@@ -95,7 +95,7 @@ sudo apt-get install clang cmake libsdl2-dev
 - [ ] ROL
 - [ ] ROR
 - [ ] RTI
-- [ ] RTS
+- [x] RTS
 - [ ] SBC
 - [ ] SEC
 - [ ] SED

--- a/test/opcodes/CMakeLists.txt
+++ b/test/opcodes/CMakeLists.txt
@@ -10,11 +10,14 @@ set(Tests
   bvc_test
   bvs_test
   cpy_test
+  jmp_test
+  jsr_test
   lda_test
   ldx_test
   ldy_test
   nop_test
   pha_test
+  rts_test
   sta_test
   stx_test
   sty_test

--- a/test/opcodes/jmp_test.c
+++ b/test/opcodes/jmp_test.c
@@ -1,0 +1,51 @@
+#include "unity.h"
+#include "cpu.h"
+
+char JMP_Absolute = 0x4C;
+char JMP_Indirect = 0x6C;
+
+struct BUS bus;
+struct CPU cpu;
+
+void setUp(void) {
+  bus = initializeBus();
+  writeBus(0xFFFC, 0x00, &bus);
+  writeBus(0xFFFD, 0x06, &bus);
+  resetCpu(&cpu, &bus);
+}
+
+void tearDown(void) {
+}
+
+void should_jump_program_counter_with_a_new_absulute_location(void) {
+  writeBus(0x600, JMP_Absolute, &bus);
+  writeBus(0x601, 0x00, &bus);
+  writeBus(0x602, 0x44, &bus);
+
+  // JMP $4400
+  clockCpu(&cpu, &bus);
+
+  TEST_ASSERT_EQUAL(0x4400, cpu.pc);
+}
+
+void should_jump_program_counter_with_a_new_indirect_location(void) {
+  writeBus(0x4400, 0x00, &bus);
+  writeBus(0x4401, 0x06, &bus);
+
+  writeBus(0x600, JMP_Indirect, &bus);
+  writeBus(0x601, 0x00, &bus);
+  writeBus(0x602, 0x44, &bus);
+
+  // JMP ($4400)
+  clockCpu(&cpu, &bus);
+
+  TEST_ASSERT_EQUAL(0x0600, cpu.pc);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(should_jump_program_counter_with_a_new_absulute_location);
+
+    return UNITY_END();
+}

--- a/test/opcodes/jsr_test.c
+++ b/test/opcodes/jsr_test.c
@@ -1,0 +1,39 @@
+#include "unity.h"
+#include "cpu.h"
+
+int stackEndAddress = 0x100; 
+char JSR = 0x20;
+
+struct BUS bus;
+struct CPU cpu;
+
+void setUp(void) {
+  bus = initializeBus();
+  writeBus(0xFFFC, 0x00, &bus);
+  writeBus(0xFFFD, 0x06, &bus);
+  resetCpu(&cpu, &bus);
+}
+
+void tearDown(void) {
+}
+
+void should_jump_to_subrotine_program_counter_and_save_current_pc_on_stack(void) {
+  writeBus(0x600, JSR, &bus);
+  writeBus(0x601, 0x00, &bus);
+  writeBus(0x602, 0x44, &bus);
+
+  // JSR $4400
+  clockCpu(&cpu, &bus);
+
+  TEST_ASSERT_EQUAL(0x4400, cpu.pc);
+  TEST_ASSERT_EQUAL(0x02, readBus(stackEndAddress + cpu.stack_pointer+1, &bus));
+  TEST_ASSERT_EQUAL(0x06, readBus(stackEndAddress + cpu.stack_pointer+2, &bus));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(should_jump_to_subrotine_program_counter_and_save_current_pc_on_stack);
+
+    return UNITY_END();
+}

--- a/test/opcodes/rts_test.c
+++ b/test/opcodes/rts_test.c
@@ -1,0 +1,38 @@
+#include "unity.h"
+#include "cpu.h"
+
+int stackEndAddress = 0x100; 
+char RTS = 0x60;
+
+struct BUS bus;
+struct CPU cpu;
+
+void setUp(void) {
+  bus = initializeBus();
+  writeBus(0xFFFC, 0x00, &bus);
+  writeBus(0xFFFD, 0x06, &bus);
+  resetCpu(&cpu, &bus);
+}
+
+void tearDown(void) {
+}
+
+void should_jump_back_to_sp_jsr_address(void) {
+  writeBus(stackEndAddress + cpu.stack_pointer+1, 0x02, &bus);
+  writeBus(stackEndAddress + cpu.stack_pointer+2, 0x06, &bus);
+
+  writeBus(0x600, RTS, &bus);
+
+  // RTS
+  clockCpu(&cpu, &bus);
+
+  TEST_ASSERT_EQUAL(0x0603, cpu.pc);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(should_jump_back_to_sp_jsr_address);
+
+    return UNITY_END();
+}


### PR DESCRIPTION
## JMP
JMP transfers program execution to the following address (absolute) or to the location contained in the following address (indirect). Note that there is no carry associated with the indirect jump so:

AN INDIRECT JUMP MUST NEVER USE A
VECTOR BEGINNING ON THE LAST BYTE
OF A PAGE

For example if address $3000 contains $40, $30FF contains $80, and $3100 contains $50, the result of JMP ($30FF) will be a transfer of control to $4080 rather than $5080 as you intended i.e. the 6502 took the low byte of the address from $30FF and the high byte from $3000.

## JSR
JSR pushes the address-1 of the next operation on to the stack before transferring program control to the following address. Subroutines are normally terminated by a RTS op code. 

## RTS
RTS pulls the top two bytes off the stack (low byte first) and transfers program control to that address+1. It is used, as expected, to exit a subroutine invoked via JSR which pushed the address-1. 