### PR TITLE
feat: Adds RTI Opcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ sudo apt-get install clang cmake libsdl2-dev
 - [ ] PLP
 - [x] ROL
 - [x] ROR
-- [ ] RTI
+- [x] RTI
 - [x] RTS
 - [ ] SBC
 - [ ] SEC

--- a/src/cpu.c
+++ b/src/cpu.c
@@ -199,6 +199,9 @@ int clockCpu(struct CPU *cpu, struct BUS *bus) {
       case ROR:
         rorOpcode(address, cpu, bus);
         break;
+      case RTI:
+        rtiOpcode(address, cpu, bus);
+        break;
       case RTS:
         rtsOpcode(address, cpu, bus);
         break;

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -20,6 +20,16 @@ int hexToDecimalMode(unsigned char hex) {
   return (hi * 10) + lo;
 }
 
+void setStatusByChar(unsigned char value, struct CPU *cpu) {
+  cpu->status.carry = (value >> 0) & 0x1;
+  cpu->status.zero = (value >> 1) & 0x1;
+  cpu->status.interrupt = (value >> 2) & 0x1;
+  cpu->status.decimal = (value >> 3) & 0x1;
+  cpu->status.break_cmd = (value >> 4) & 0x1;
+  cpu->status.overflow = (value >> 6) & 0x1;
+  cpu->status.negative = (value >> 7) & 0x1;
+}
+
 bool isAccumulatorAddressMode(unsigned int address) {
   return address == 0;
 }
@@ -201,6 +211,16 @@ void rorOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus)
   cpu->status.zero = result == 0x00;
 
   writeOnMemoryOrAccumulator(address, result, cpu, bus);
+}
+
+void rtiOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus)
+{
+  char setBreakFalse = ~0x10;
+  setStatusByChar(popStack(cpu, bus) & setBreakFalse, cpu);
+
+  unsigned char lo = popStack(cpu, bus);
+  unsigned char hi = popStack(cpu, bus);
+  cpu->pc = (hi << 8) | lo;
 }
 
 void rtsOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus)

--- a/src/opcodes.c
+++ b/src/opcodes.c
@@ -215,8 +215,9 @@ void rorOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus)
 
 void rtiOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus)
 {
-  char setBreakFalse = ~0x10;
-  setStatusByChar(popStack(cpu, bus) & setBreakFalse, cpu);
+  char setBreakFlagFalse = ~0x10;
+  unsigned char flagsValue = popStack(cpu, bus);
+  setStatusByChar(flagsValue & setBreakFlagFalse, cpu);
 
   unsigned char lo = popStack(cpu, bus);
   unsigned char hi = popStack(cpu, bus);

--- a/src/opcodes.h
+++ b/src/opcodes.h
@@ -24,6 +24,7 @@ void nopOpcode();
 void phaOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
 void rolOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
 void rorOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
+void rtiOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
 void rtsOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
 void staOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);
 void stxOpcode(unsigned int address, struct CPU *cpu, struct BUS *bus);

--- a/test/opcodes/CMakeLists.txt
+++ b/test/opcodes/CMakeLists.txt
@@ -21,6 +21,7 @@ set(Tests
   pha_test
   rol_test
   ror_test
+  rti_test
   rts_test
   sta_test
   stx_test

--- a/test/opcodes/rti_test.c
+++ b/test/opcodes/rti_test.c
@@ -1,0 +1,48 @@
+#include "unity.h"
+#include "cpu.h"
+
+int stackEndAddress = 0x100;
+char RTI = 0x40;
+
+struct BUS bus;
+struct CPU cpu;
+
+void setUp(void) {
+  bus = initializeBus();
+  writeBus(0xFFFC, 0x00, &bus);
+  writeBus(0xFFFD, 0x06, &bus);
+  resetCpu(&cpu, &bus);
+}
+
+void tearDown(void) {
+}
+
+void should_set_pc_and_status_flags(void) {
+  writeBus(stackEndAddress + cpu.stack_pointer, 0x06, &bus);
+  cpu.stack_pointer--;
+  writeBus(stackEndAddress + cpu.stack_pointer, 0x02, &bus);
+  cpu.stack_pointer--;
+  writeBus(stackEndAddress + cpu.stack_pointer, 0xFF, &bus);
+  cpu.stack_pointer--;
+
+  writeBus(0x600, RTI, &bus);
+
+  clockCpu(&cpu, &bus);
+
+  TEST_ASSERT_EQUAL(0x0602, cpu.pc);
+  TEST_ASSERT_EQUAL(true, cpu.status.carry);
+  TEST_ASSERT_EQUAL(true, cpu.status.zero);
+  TEST_ASSERT_EQUAL(true, cpu.status.interrupt);
+  TEST_ASSERT_EQUAL(true, cpu.status.decimal);
+  TEST_ASSERT_EQUAL(false, cpu.status.break_cmd);
+  TEST_ASSERT_EQUAL(true, cpu.status.overflow);
+  TEST_ASSERT_EQUAL(true, cpu.status.negative);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+
+    RUN_TEST(should_set_pc_and_status_flags);
+
+    return UNITY_END();
+}

--- a/test/opcodes/rts_test.c
+++ b/test/opcodes/rts_test.c
@@ -18,8 +18,10 @@ void tearDown(void) {
 }
 
 void should_jump_back_to_sp_jsr_address(void) {
-  writeBus(stackEndAddress + cpu.stack_pointer+1, 0x02, &bus);
-  writeBus(stackEndAddress + cpu.stack_pointer+2, 0x06, &bus);
+  writeBus(stackEndAddress + cpu.stack_pointer, 0x06, &bus);
+  cpu.stack_pointer--;
+  writeBus(stackEndAddress + cpu.stack_pointer, 0x02, &bus);
+  cpu.stack_pointer--;
 
   writeBus(0x600, RTS, &bus);
 


### PR DESCRIPTION
### RTI (ReTurn from Interrupt)

Affects Flags: all

RTI retrieves the Processor Status Word (flags) and the Program Counter from the stack in that order (interrupts push the PC first and then the PSW).

Note that unlike RTS, the return address on the stack is the actual address rather than the address-1. 