### PR TITLE
fix: Exit codes on File Open Functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ setup:
 .PHONY: setup
 
 debug:
-	make --no-print-directory -C build/debug
+	make --no-print-directory -C build/debug -j
 .PHONY: debug
 
 release:
-	make --no-print-directory -C build/release
+	make --no-print-directory -C build/release -j
 .PHONY: release
 
 test:
-	make --no-print-directory -C build/debug
+	make --no-print-directory -C build/debug -j
 	make --no-print-directory -C build/debug test ARGS='--output-on-failure'
 .PHONY: test
 

--- a/app/6502.c
+++ b/app/6502.c
@@ -2,11 +2,11 @@
 #include "cpu.h"
 #include "sdl.h"
 
-void initSimulator (struct CPU * cpu, struct BUS * bus, int initial_address, char * programPath) {
+int initSimulator (struct CPU * cpu, struct BUS * bus, int initial_address, char * programPath) {
   writeBus(0xFFFC, initial_address & 0xff, bus);
   writeBus(0xFFFD, (initial_address >> 8), bus);
   resetCpu(cpu, bus);
-  writeProgramToBus(programPath, initial_address, bus);
+  return writeProgramToBus(programPath, initial_address, bus);
 }
 
 void loop(SDL_Renderer *rend, struct CPU * cpu, struct BUS * bus) {
@@ -32,7 +32,9 @@ int main(int argc, char **argv)
 
   struct CPU cpu;
   struct BUS bus = initializeBus();
-  initSimulator(&cpu, &bus, 0x0600, programPath);
+
+  if(initSimulator(&cpu, &bus, 0x0600, programPath) != 0) 
+    return 1;
 
   SDL_Window* win = initWindowSdl();
   SDL_Renderer* rend = initRenderSDL(win);

--- a/app/6502_disasm.c
+++ b/app/6502_disasm.c
@@ -10,7 +10,14 @@ int main(int argc, char **argv)
   } else {
     programPath = "resources/dump.bin";
   }
-  struct PROGRAM programLoaded = LoadBinary(programPath);
+
+  struct PROGRAM programLoaded = {
+    .program = NULL,
+    .lines = 0
+  };
+
+  if(LoadBinary(programPath, &programLoaded) != 0) 
+    return 1;
 
   printf("Address  Hexdump   Dissassembly\n");
   printf("-------------------------------\n");

--- a/src/bus.c
+++ b/src/bus.c
@@ -61,22 +61,22 @@ unsigned char readBus(unsigned int addr, struct BUS * bus) {
   return data;
 }
 
-void writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus) {
+int writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus) {
   if(strlen(filePath) <= 0) {
     printf("invalid file path %s", filePath);
-    exit(0);
+    return 1;
   }
 
   if(access(filePath, F_OK) != 0) {
     printf("file not found %s", filePath);
-    exit(0);
+    return 1;
   }
 
   FILE * file = fopen(filePath, "r");
 
   if(file == NULL) {
     printf("error opening file %s", filePath);
-    exit(0);
+    return 1;
   }
 
   unsigned char buffer;
@@ -85,4 +85,6 @@ void writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus) {
     writeBus(current_offset, buffer, bus);
     current_offset++;
   }
+
+  return 0;
 }

--- a/src/bus.c
+++ b/src/bus.c
@@ -63,19 +63,19 @@ unsigned char readBus(unsigned int addr, struct BUS * bus) {
 
 int writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus) {
   if(strlen(filePath) <= 0) {
-    printf("invalid file path %s", filePath);
+    fprintf(stderr, "invalid file path %s", filePath);
     return 1;
   }
 
   if(access(filePath, F_OK) != 0) {
-    printf("file not found %s", filePath);
+    fprintf(stderr, "file not found %s", filePath);
     return 1;
   }
 
   FILE * file = fopen(filePath, "r");
 
   if(file == NULL) {
-    printf("error opening file %s", filePath);
+    fprintf(stderr, "error opening file %s", filePath);
     return 1;
   }
 

--- a/src/bus.h
+++ b/src/bus.h
@@ -7,4 +7,4 @@ struct BUS {
 struct BUS initializeBus();
 void writeBus(unsigned int addr, unsigned char data, struct BUS * bus);
 unsigned char readBus(unsigned int addr, struct BUS * bus);
-void writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus);
+int writeProgramToBus(char * filePath, unsigned int offset, struct BUS * bus);

--- a/src/disassembler.c
+++ b/src/disassembler.c
@@ -19,19 +19,19 @@ struct OPCODE * GetOpcode(unsigned char hex) {
 
 int LoadBinary(char * binaryPath, struct PROGRAM * programLoaded) {
   if(strlen(binaryPath) <= 0) {
-    printf("invalid file path %s", binaryPath);
+    fprintf(stderr, "invalid file path %s", binaryPath);
     return 1;
   }
 
   if(access(binaryPath, F_OK) != 0) {
-    printf("file not found %s", binaryPath);
+    fprintf(stderr, "file not found %s", binaryPath);
     return 1;
   }
 
   FILE * file = fopen(binaryPath, "r");
 
   if(file == NULL) {
-    printf("error opening file %s", binaryPath);
+    fprintf(stderr, "error opening file %s", binaryPath);
     return 1;
   }
 

--- a/src/disassembler.c
+++ b/src/disassembler.c
@@ -17,22 +17,22 @@ struct OPCODE * GetOpcode(unsigned char hex) {
   return NULL;
 }
 
-struct PROGRAM LoadBinary(char * binaryPath) {
+int LoadBinary(char * binaryPath, struct PROGRAM * programLoaded) {
   if(strlen(binaryPath) <= 0) {
     printf("invalid file path %s", binaryPath);
-    exit(0);
+    return 1;
   }
 
   if(access(binaryPath, F_OK) != 0) {
     printf("file not found %s", binaryPath);
-    exit(0);
+    return 1;
   }
 
   FILE * file = fopen(binaryPath, "r");
 
   if(file == NULL) {
     printf("error opening file %s", binaryPath);
-    exit(0);
+    return 1;
   }
 
   // count file size
@@ -75,12 +75,10 @@ struct PROGRAM LoadBinary(char * binaryPath) {
 
   fclose(file);
 
-  struct PROGRAM programLoaded = {
-    .program = program,
-    .lines = programLine + 1
-  };
+  programLoaded->program = program;
+  programLoaded->lines = programLine + 1;
 
-  return programLoaded;
+  return 0;
 }
 
 char * toStringHex(struct PROGRAM_LINE * line) {

--- a/src/disassembler.h
+++ b/src/disassembler.h
@@ -1,6 +1,6 @@
 #include "program.h"
 
 struct OPCODE * GetOpcode(unsigned char hex);
-struct PROGRAM LoadBinary(char * binaryPath);
+int LoadBinary(char * binaryPath, struct PROGRAM * programLoaded);
 char* toStringHex(struct PROGRAM_LINE * line);
 char* toStringAsm(struct PROGRAM_LINE * line);

--- a/test/bus_test.c
+++ b/test/bus_test.c
@@ -68,11 +68,18 @@ void test_function_should_exit_1_when_file_cant_be_readed(void) {
   remove(filename);
 }
 
+void test_function_should_exit_1_when_no_file_provided(void) {
+  int exitCode = writeProgramToBus("", 0, &bus);
+  TEST_ASSERT_EQUAL(1, exitCode);
+}
+
 int main(void) {
     UNITY_BEGIN();
 
     RUN_TEST(test_function_should_save_get_memory_data);
     RUN_TEST(test_function_should_write_program_to_bus);
+
+    RUN_TEST(test_function_should_exit_1_when_no_file_provided);
     RUN_TEST(test_function_should_exit_1_when_file_doenst_exist);
     RUN_TEST(test_function_should_exit_1_when_path_doenst_exist);
     RUN_TEST(test_function_should_exit_1_when_file_cant_be_readed);

--- a/test/bus_test.c
+++ b/test/bus_test.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include "unity.h"
 #include "bus.h"
+#include <sys/stat.h>
 
 struct BUS bus;
 
@@ -44,13 +45,37 @@ void test_function_should_write_program_to_bus(void){
   TEST_ASSERT_EQUAL(0x0, readBus(0x0135, &bus));
 }
 
-typedef void (*Func)(void);
+void test_function_should_exit_1_when_file_doenst_exist(void) {
+  int exitCode = writeProgramToBus("./nothing", 0, &bus);
+  TEST_ASSERT_EQUAL(1, exitCode);
+}
+
+void test_function_should_exit_1_when_path_doenst_exist(void) {
+  int exitCode = writeProgramToBus("./nothing/nope", 0, &bus);
+  TEST_ASSERT_EQUAL(1, exitCode);
+}
+
+void test_function_should_exit_1_when_file_cant_be_readed(void) {
+  char * filename = "youcantreadthis";
+  FILE * fptr;
+  fptr = fopen(filename, "w");
+  fclose(fptr);
+  chmod(filename, 0x007);
+
+  int exitCode = writeProgramToBus(filename, 0, &bus);
+  TEST_ASSERT_EQUAL(1, exitCode);
+
+  remove(filename);
+}
 
 int main(void) {
     UNITY_BEGIN();
 
     RUN_TEST(test_function_should_save_get_memory_data);
     RUN_TEST(test_function_should_write_program_to_bus);
+    RUN_TEST(test_function_should_exit_1_when_file_doenst_exist);
+    RUN_TEST(test_function_should_exit_1_when_path_doenst_exist);
+    RUN_TEST(test_function_should_exit_1_when_file_cant_be_readed);
 
     return UNITY_END();
 }

--- a/test/bus_test.c
+++ b/test/bus_test.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
+#include <sys/stat.h>
 #include "unity.h"
 #include "bus.h"
-#include <sys/stat.h>
 
 struct BUS bus;
 


### PR DESCRIPTION
Instead of just breaking the program flow, what would be pretty hard/nasty to test, I've returned the status codes directly.
Consider this as a WIP by now.

We must understand whether the CI machine can remove a file with almost no privileges or not. (chmod 007)
Then, if this proves to be a good way to move forward, refactor other parts like changing method signatures will be necessary aswell.  

Almost forgot to mention, this is a way to address the to close  #38  