### PR TITLE
fix: fixes jumping to unknown location

### DIFF
--- a/app/6502.c
+++ b/app/6502.c
@@ -34,7 +34,10 @@ void loop(struct CPU * cpu, struct BUS * bus) {
     generateRandomByte(bus);
     handleInput(bus);
     drawScreen(scale, bus->display);
-    clockCpu(cpu, bus);
+
+    if (cpu->pc != 0) {
+      clockCpu(cpu, bus);
+    }
   }
 }
 


### PR DESCRIPTION
This pull request fixes jumps to locations beyond the limits and as it is follows how easy6502 handle jumps to unknown locations. 
Well, that means not showing a lot of "ERROR: INVALID OPCODE ..." when collision detected in `./resources/snake.bin`

For better understanding of this weird `if`:
![image](https://user-images.githubusercontent.com/6990857/121343495-21897300-c8f9-11eb-86c6-72b12786eeb5.png)
